### PR TITLE
Use rubocop-0.42

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/rubocop"]
-	path = vendor/rubocop
-	url = git@github.com:bbatsov/rubocop.git

--- a/rubocop-definition_validator.gemspec
+++ b/rubocop-definition_validator.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'rubocop', '~> 0.42.0'
 
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency 'guard', '~> 2.13.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,17 +18,10 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'rubocop'
+require 'rubocop/rspec/support'
 require 'rspec-power_assert'
 require 'pry'
 require 'pry_testcase/rspec'
-
-rubocop_path = File.join(File.dirname(__FILE__), '../vendor/rubocop')
-
-unless File.directory?(rubocop_path)
-  raise "Can't run specs without a local RuboCop checkout. Look in the README."
-end
-
-Dir["#{rubocop_path}/spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Rubocop 0.42, the latest version as of today, ships with spec helper files.
Having development dependency to 0.42 allows us deleting rubocop source code in `vendor/rubocop`.